### PR TITLE
Should fix the metadata bug

### DIFF
--- a/oops/surface/centricellipsoid.py
+++ b/oops/surface/centricellipsoid.py
@@ -22,14 +22,18 @@ class CentricEllipsoid(Ellipsoid):
             pos         a Vector3 of positions at or near the surface, relative
                         to this surface's origin and frame.
             obs         a Vector3 of observer position relative to this
-                        surface's origin and frame; ignored here.
-            time        a Scalar time at which to evaluate the surface; ignored.
-            axes        2 or 3, indicating whether to return a tuple of two or
-                        three Scalar objects.
+                        surface's origin and frame; ignored for this Surface
+                        subclass.
+            time        a Scalar time at which to evaluate the surface; ignored
+                        for this Surface subclass.
+            axes        2 or 3, indicating whether to return the first two
+                        coordinates (lon, lat) or all three (lon, lat, z) as
+                        Scalars.
             derivs      True to propagate any derivatives inside pos and obs
                         into the returned coordinates.
-            hints       if provided, the value of the coefficient p such that
-                            ground + p * normal(ground) = pos
+            hints       optionally, the value of the coefficient p such that
+                            ground + p * normal(ground) = pos;
+                        ignored if the value is None (the default) or True.
             groundtrack True to return the intercept on the surface along with
                         the coordinates.
 
@@ -38,7 +42,7 @@ class CentricEllipsoid(Ellipsoid):
             lat         latitude at the surface in radians.
             z           vertical altitude in km normal to the surface; included
                         if axes == 3.
-            groundtrack intecept point on the surface (where z == 0); included
+            track       intercept point on the surface (where z == 0); included
                         if input groundtrack is True.
         """
 
@@ -48,12 +52,12 @@ class CentricEllipsoid(Ellipsoid):
         pos = Vector3.as_vector3(pos, recursive=derivs)
 
         # Use the quick solution for the body points if hints are provided
-        if hints is not None:
+        if isinstance(hints, (type(None), bool, np.bool_)):
+            (track, p) = self.intercept_normal_to(pos, guess=True)
+        else:
             p = Scalar.as_scalar(hints, recursive=derivs)
             denom = Vector3.ONES + p * self.unsquash_sq
             track = pos.element_div(denom)
-        else:
-            (track, p) = self.intercept_normal_to(pos, guess=True)
 
         # Derive the coordinates
         (x,y,z) = track.to_scalars()
@@ -79,26 +83,26 @@ class CentricEllipsoid(Ellipsoid):
 
         Input:
             coords      a tuple of two or three Scalars defining coordinates at
-                        or near this surface.
+                        or near this surface. These can have different shapes,
+                        but must be broadcastable to a common shape.
                 lon     longitude at the surface in radians.
                 lat     latitude at the surface in radians.
                 z       vertical altitude in km normal to the body surface.
             obs         a Vector3 of observer position relative to this
-                        surface's origin and frame; ignored here.
-            time        a Scalar time at which to evaluate the surface; ignored.
+                        surface's origin and frame; ignored for this Surface
+                        subclass.
+            time        a Scalar time at which to evaluate the surface; ignored
+                        for this Surface subclass.
             derivs      True to propagate any derivatives inside the coordinates
                         and obs into the returned position vectors.
             groundtrack True to include the associated groundtrack points on the
                         body surface in the returned result.
 
-        Return:         pos or (pos, groundtrack), where
+        Return:         pos or (pos, track), where
             pos         a Vector3 of points defined by the coordinates, relative
                         to this surface's origin and frame.
-            groundtrack True to include the associated groundtrack points on the
-                        body surface in the returned result.
-
-        Note that the coordinates can all have different shapes, but they must
-        be broadcastable to a single shape.
+            track       intercept point on the surface (where z == 0); included
+                        if input groundtrack is True.
         """
 
         # Validate inputs

--- a/oops/surface/centricspheroid.py
+++ b/oops/surface/centricspheroid.py
@@ -23,15 +23,18 @@ class CentricSpheroid(Spheroid):
             pos         a Vector3 of positions at or near the surface, relative
                         to this surface's origin and frame.
             obs         a Vector3 of observer position relative to this
-                        surface's origin and frame; ignored here.
-            time        a Scalar time at which to evaluate the surface; ignored.
-            axes        2 or 3, indicating whether to return a tuple of two or
-                        three Scalar objects.
+                        surface's origin and frame; ignored for this Surface
+                        subclass.
+            time        a Scalar time at which to evaluate the surface; ignored
+                        for this Surface subclass.
+            axes        2 or 3, indicating whether to return the first two
+                        coordinates (lon, lat) or all three (lon, lat, z) as
+                        Scalars.
             derivs      True to propagate any derivatives inside pos and obs
                         into the returned coordinates.
-            hints       if provided, the value of the coefficient p such that
-                            ground + p * normal(ground) = pos
-                        for the ground point on the body surface.
+            hints       optionally, the value of the coefficient p such that
+                            ground + p * normal(ground) = pos;
+                        ignored if the value is None (the default) or True.
             groundtrack True to return the intercept on the surface along with
                         the coordinates.
 
@@ -40,7 +43,7 @@ class CentricSpheroid(Spheroid):
             lat         latitude at the surface in radians.
             z           vertical altitude in km normal to the surface; included
                         if axes == 3.
-            groundtrack intecept point on the surface (where z == 0); included
+            track       intercept point on the surface (where z == 0); included
                         if input groundtrack is True.
         """
 
@@ -56,26 +59,26 @@ class CentricSpheroid(Spheroid):
 
         Input:
             coords      a tuple of two or three Scalars defining coordinates at
-                        or near this surface.
+                        or near this surface. These can have different shapes,
+                        but must be broadcastable to a common shape.
                 lon     longitude at the surface in radians.
                 lat     latitude at the surface in radians.
                 z       vertical altitude in km normal to the body surface.
             obs         a Vector3 of observer position relative to this
-                        surface's origin and frame; ignored here.
-            time        a Scalar time at which to evaluate the surface; ignored.
+                        surface's origin and frame; ignored for this Surface
+                        subclass.
+            time        a Scalar time at which to evaluate the surface; ignored
+                        for this Surface subclass.
             derivs      True to propagate any derivatives inside the coordinates
                         and obs into the returned position vectors.
             groundtrack True to include the associated groundtrack points on the
                         body surface in the returned result.
 
-        Return:         pos or (pos, groundtrack), where
+        Return:         pos or (pos, track), where
             pos         a Vector3 of points defined by the coordinates, relative
                         to this surface's origin and frame.
-            groundtrack True to include the associated groundtrack points on the
-                        body surface in the returned result.
-
-        Note that the coordinates can all have different shapes, but they must
-        be broadcastable to a single shape.
+            track       intercept point on the surface (where z == 0); included
+                        if input groundtrack is True.
         """
 
         # Validate inputs

--- a/oops/surface/graphicellipsoid.py
+++ b/oops/surface/graphicellipsoid.py
@@ -28,15 +28,18 @@ class GraphicEllipsoid(Ellipsoid):
             pos         a Vector3 of positions at or near the surface, relative
                         to this surface's origin and frame.
             obs         a Vector3 of observer position relative to this
-                        surface's origin and frame; ignored here.
-            time        a Scalar time at which to evaluate the surface; ignored.
-            axes        2 or 3, indicating whether to return a tuple of two or
-                        three Scalar objects.
+                        surface's origin and frame; ignored for this Surface
+                        subclass.
+            time        a Scalar time at which to evaluate the surface; ignored
+                        for this Surface subclass.
+            axes        2 or 3, indicating whether to return the first two
+                        coordinates (lon, lat) or all three (lon, lat, z) as
+                        Scalars.
             derivs      True to propagate any derivatives inside pos and obs
                         into the returned coordinates.
-            hints       if provided, the value of the coefficient p such that
-                            ground + p * normal(ground) = pos
-                        for the ground point on the body surface.
+            hints       optionally, the value of the coefficient p such that
+                            ground + p * normal(ground) = pos;
+                        ignored if the value is None (the default) or True.
             groundtrack True to return the intercept on the surface along with
                         the coordinates.
 
@@ -45,7 +48,7 @@ class GraphicEllipsoid(Ellipsoid):
             lat         latitude at the surface in radians.
             z           vertical altitude in km normal to the surface; included
                         if axes == 3.
-            groundtrack intecept point on the surface (where z == 0); included
+            track       intercept point on the surface (where z == 0); included
                         if input groundtrack is True.
         """
 
@@ -55,12 +58,12 @@ class GraphicEllipsoid(Ellipsoid):
         pos = Vector3.as_vector3(pos, recursive=derivs)
 
         # Use the quick solution for the body points if hints are provided
-        if hints is not None:
+        if isinstance(hints, (type(None), bool, np.bool_)):
+            (track, p) = self.intercept_normal_to(pos, guess=True)
+        else:
             p = Scalar.as_scalar(hints, recursive=derivs)
             denom = Vector3.ONES + p * self.unsquash_sq
             track = pos.element_div(denom)
-        else:
-            (track, p) = self.intercept_normal_to(pos, guess=True)
 
         # Derive the coordinates
         normal = track.element_mul(self.unsquash_sq)
@@ -87,26 +90,26 @@ class GraphicEllipsoid(Ellipsoid):
 
         Input:
             coords      a tuple of two or three Scalars defining coordinates at
-                        or near this surface.
+                        or near this surface. These can have different shapes,
+                        but must be broadcastable to a common shape.
                 lon     longitude at the surface in radians.
                 lat     latitude at the surface in radians.
                 z       vertical altitude in km normal to the body surface.
             obs         a Vector3 of observer position relative to this
-                        surface's origin and frame; ignored here.
-            time        a Scalar time at which to evaluate the surface; ignored.
+                        surface's origin and frame; ignored for this Surface
+                        subclass.
+            time        a Scalar time at which to evaluate the surface; ignored
+                        for this Surface subclass.
             derivs      True to propagate any derivatives inside the coordinates
                         and obs into the returned position vectors.
             groundtrack True to include the associated groundtrack points on the
                         body surface in the returned result.
 
-        Return:         pos or (pos, groundtrack), where
+        Return:         pos or (pos, track), where
             pos         a Vector3 of points defined by the coordinates, relative
                         to this surface's origin and frame.
-            groundtrack True to include the associated groundtrack points on the
-                        body surface in the returned result.
-
-        Note that the coordinates can all have different shapes, but they must
-        be broadcastable to a single shape.
+            track       intercept point on the surface (where z == 0); included
+                        if input groundtrack is True.
         """
 
         # Validate inputs

--- a/oops/surface/graphicspheroid.py
+++ b/oops/surface/graphicspheroid.py
@@ -22,15 +22,19 @@ class GraphicSpheroid(Spheroid):
             pos         a Vector3 of positions at or near the surface, relative
                         to this surface's origin and frame.
             obs         a Vector3 of observer position relative to this
-                        surface's origin and frame; ignored here.
-            time        a Scalar time at which to evaluate the surface; ignored.
-            axes        2 or 3, indicating whether to return a tuple of two or
-                        three Scalar objects.
+                        surface's origin and frame; ignored for this Surface
+                        subclass.
+            time        a Scalar time at which to evaluate the surface; ignored
+                        for this Surface subclass.
+            axes        2 or 3, indicating whether to return the first two
+                        coordinates (lon, lat) or all three (lon, lat, z) as
+                        Scalars.
             derivs      True to propagate any derivatives inside pos and obs
                         into the returned coordinates.
-            hints       if provided, the value of the coefficient p such that
-                            ground + p * normal(ground) = pos
-                        for the ground point on the body surface.
+            hints       optionally, the value of the coefficient p such that
+                            ground + p * normal(ground) = pos;
+                        for the ground point on the body surface. Ignored if the
+                        value is None (the default) or True.
             groundtrack True to return the intercept on the surface along with
                         the coordinates.
 
@@ -39,7 +43,7 @@ class GraphicSpheroid(Spheroid):
             lat         latitude at the surface in radians.
             z           vertical altitude in km normal to the surface; included
                         if axes == 3.
-            groundtrack intecept point on the surface (where z == 0); included
+            track       intercept point on the surface (where z == 0); included
                         if input groundtrack is True.
         """
 
@@ -55,13 +59,16 @@ class GraphicSpheroid(Spheroid):
 
         Input:
             coords      a tuple of two or three Scalars defining coordinates at
-                        or near this surface.
+                        or near this surface. These can have different shapes,
+                        but must be broadcastable to a common shape.
                 lon     longitude at the surface in radians.
                 lat     latitude at the surface in radians.
                 z       vertical altitude in km normal to the body surface.
             obs         a Vector3 of observer position relative to this
-                        surface's origin and frame; ignored here.
-            time        a Scalar time at which to evaluate the surface; ignored.
+                        surface's origin and frame; ignored for this Surface
+                        subclass.
+            time        a Scalar time at which to evaluate the surface; ignored
+                        for this Surface subclass.
             derivs      True to propagate any derivatives inside the coordinates
                         and obs into the returned position vectors.
             groundtrack True to include the associated groundtrack points on the
@@ -70,11 +77,8 @@ class GraphicSpheroid(Spheroid):
         Return:         pos or (pos, groundtrack), where
             pos         a Vector3 of points defined by the coordinates, relative
                         to this surface's origin and frame.
-            groundtrack True to include the associated groundtrack points on the
-                        body surface in the returned result.
-
-        Note that the coordinates can all have different shapes, but they must
-        be broadcastable to a single shape.
+            track       intercept point on the surface (where z == 0); included
+                        if input groundtrack is True.
         """
 
         # Validate inputs

--- a/oops/surface/nullsurface.py
+++ b/oops/surface/nullsurface.py
@@ -54,10 +54,13 @@ class NullSurface(Surface):
             pos         a Vector3 of positions at or near the surface, relative
                         to this surface's origin and frame.
             obs         a Vector3 of observer position relative to this
-                        surface's origin and frame; ignored here.
-            time        a Scalar time at which to evaluate the surface; ignored.
-            axes        2 or 3, indicating whether to return a tuple of two or
-                        three Scalar objects.
+                        surface's origin and frame; ignored for this Surface
+                        subclass.
+            time        a Scalar time at which to evaluate the surface; ignored
+                        for this Surface subclass.
+            axes        2 or 3, indicating whether to return the first two
+                        coordinates (x, y) or all three (x, y, z) coordinates as
+                        Scalars.
             derivs      True to propagate any derivatives inside pos and obs
                         into the returned coordinates.
             guess       ignored.
@@ -82,17 +85,18 @@ class NullSurface(Surface):
             coords      a tuple of two or three Scalars defining coordinates at
                         or near this surface. These are the (x,y,z) rectangular
                         coordinates relative to the surface's origin and frame.
+                        They can have different shapes, but must be
+                        broadcastable to a common shape.
             obs         a Vector3 of observer position relative to this
-                        surface's origin and frame. Ignored for solid surfaces.
-            time        a Scalar time at which to evaluate the surface; ignored.
+                        surface's origin and frame; ignored for this Surface
+                        subclass.
+            time        a Scalar time at which to evaluate the surface; ignored
+                        for this Surface subclass.
             derivs      True to propagate any derivatives inside the coordinates
                         and obs into the returned position vectors.
 
         Return:         a Vector3 of points defined by the coordinates, relative
                         to this surface's origin and frame.
-
-        Note that the coordinates can all have different shapes, but they must
-        be broadcastable to a single shape.
         """
 
         # Validate inputs
@@ -119,20 +123,24 @@ class NullSurface(Surface):
             obs         observer position as a Vector3 relative to this
                         surface's origin and frame.
             los         line of sight as a Vector3 in this surface's frame.
-            time        a Scalar time at the surface; ignored unless the surface
-                        is time-variable.
+            time        a Scalar time at which to evaluate the surface; ignored
+                        for this Surface subclass.
             direction   'arr' for a photon arriving at the surface; 'dep' for a
                         photon departing from the surface; ignored.
             derivs      True to propagate any derivatives inside obs and los
                         into the returned intercept point.
             guess       unused.
-            hints       unused.
+            hints       if not None (the default), this value is appended to the
+                        returned tuple. Needed for compatibility with other
+                        Surface subclasses.
 
-        Return:         a tuple (pos, t) where
+        Return:         a tuple (pos, t) or (pos, t, hints), where
             pos         a Vector3 of intercept points on the surface relative
                         to this surface's origin and frame, in km.
             t           a Scalar such that:
                             intercept = obs + t * los
+            hints       the input value of hints, included if this value is not
+                        None.
         """
 
         # This is a quick way to create a position vector of the correct shape,
@@ -157,7 +165,8 @@ class NullSurface(Surface):
         Input:
             pos         a Vector3 of positions at or near the surface relative
                         to this surface's origin and frame.
-            time        a Scalar time at which to evaluate the surface; ignored.
+            time        a Scalar time at which to evaluate the surface; ignored
+                        for this Surface subclass.
             derivs      True to propagate any derivatives of pos into the
                         returned normal vectors.
 
@@ -178,7 +187,8 @@ class NullSurface(Surface):
         Input:
             pos         a Vector3 of positions at or near the surface relative
                         to this surface's origin and frame.
-            time        a Scalar time at which to evaluate the surface; ignored.
+            time        a Scalar time at which to evaluate the surface; ignored
+                        for this Surface subclass.
 
         Return:         a Vector3 of velocities, in units of km/s.
         """

--- a/oops/surface/orbitplane.py
+++ b/oops/surface/orbitplane.py
@@ -215,13 +215,16 @@ class OrbitPlane(Surface):
             pos         a Vector3 of positions at or near the surface, relative
                         to this surface's origin and frame.
             obs         a Vector3 of observer position relative to this
-                        surface's origin and frame; ignored here.
+                        surface's origin and frame; ignored for this Surface
+                        subclass.
             time        a Scalar time at which to evaluate the surface.
-            axes        2 or 3, indicating whether to return a tuple of two or
-                        three Scalar objects.
+            axes        2 or 3, indicating whether to return the first two
+                        coordinates (rad, theta) or all three (rad, theta, z) as
+                        Scalars.
             derivs      True to propagate any derivatives inside pos and obs
                         into the returned coordinates.
-            hints       ignored.
+            hints       ignored. Provided for compatibility with other Surface
+                        subclasses.
 
         Return:         coordinate values packaged as a tuple containing two or
                         three Scalars, one for each coordinate.
@@ -231,11 +234,8 @@ class OrbitPlane(Surface):
                         if axes == 3.
         """
 
-        # Validate inputs
-        self._coords_from_vector3_check(axes)
-
-        return self.ringplane.coords_from_vector3(pos, obs, axes=axes,
-                                                            derivs=derivs)
+        return self.ringplane.coords_from_vector3(pos, axes=axes, time=time,
+                                                  derivs=derivs)
 
     #===========================================================================
     def vector3_from_coords(self, coords, obs=None, time=None, derivs=False):
@@ -244,24 +244,24 @@ class OrbitPlane(Surface):
 
         Input:
             coords      a tuple of two or three Scalars defining coordinates at
-                        or near this surface.
+                        or near this surface. These can have different shapes,
+                        but must be broadcastable to a common shape.
                 rad     mean orbital radius in the ring plane, in km.
                 theta   mean longitude in radians of the intercept point.
                 z       vertical distance in km above the orbit plane.
             obs         a Vector3 of observer position relative to this
-                        surface's origin and frame; ignored here.
-            time        a Scalar time at which to evaluate the surface; ignored.
+                        surface's origin and frame; ignored for this Surface
+                        subclass.
+            time        a Scalar time at which to evaluate the surface.
             derivs      True to propagate any derivatives inside the coordinates
                         and obs into the returned position vectors.
 
         Return:         a Vector3 of points defined by the coordinates, relative
                         to this surface's origin and frame.
-
-        Note that the coordinates can all have different shapes, but they must
-        be broadcastable to a single shape.
         """
 
-        return self.ringplane.vector3_from_coords(coords, obs, derivs=derivs)
+        return self.ringplane.vector3_from_coords(coords, time=time,
+                                                  derivs=derivs)
 
     #===========================================================================
     def intercept(self, obs, los, time=None, direction='dep', derivs=False,
@@ -272,23 +272,26 @@ class OrbitPlane(Surface):
             obs         observer position as a Vector3 relative to this
                         surface's origin and frame.
             los         line of sight as a Vector3 in this surface's frame.
-            time        a Scalar time at the surface; ignored unless the surface
-                        is time-variable.
+            time        a Scalar time at the surface.
             direction   'arr' for a photon arriving at the surface; 'dep' for a
                         photon departing from the surface; ignored.
             derivs      True to propagate any derivatives inside obs and los
                         into the returned intercept point.
             guess       unused.
-            hints       unused.
+            hints       if not None (the default), this value is appended to the
+                        returned tuple. Needed for compatibility with other
+                        Surface subclasses.
 
-        Return:         a tuple (pos, t) where
+        Return:         a tuple (pos, t) or (pos, t, hints), where
             pos         a Vector3 of intercept points on the surface relative
                         to this surface's origin and frame, in km.
             t           a Scalar such that:
                             position = obs + t * los
+            hints       the input value of hints, included if it is not None.
         """
 
-        return self.ringplane.intercept(obs, los, derivs=derivs, guess=guess)
+        return self.ringplane.intercept(obs, los, time=time, derivs=derivs,
+                                        guess=guess, hints=hints)
 
     #===========================================================================
     def normal(self, pos, time=None, derivs=False):
@@ -305,7 +308,7 @@ class OrbitPlane(Surface):
                         that pass through the position. Lengths are arbitrary.
         """
 
-        return self.ringplane.normal(pos, derivs=derivs)
+        return self.ringplane.normal(pos, time=time, derivs=derivs)
 
     #===========================================================================
     def velocity(self, pos, time=None):

--- a/oops/surface/ringplane.py
+++ b/oops/surface/ringplane.py
@@ -122,13 +122,17 @@ class RingPlane(Surface):
             pos         a Vector3 of positions at or near the surface, relative
                         to this surface's origin and frame.
             obs         a Vector3 of observer position relative to this
-                        surface's origin and frame; ignored here.
-            time        a Scalar time at which to evaluate the surface; ignored.
-            axes        2 or 3, indicating whether to return a tuple of two or
-                        three Scalar objects.
+                        surface's origin and frame; ignored for this Surface
+                        subclass.
+            time        a Scalar time at which to evaluate the surface; ignored
+                        unless this RingPlane contains radial modes.
+            axes        2 or 3, indicating whether to return the first two
+                        coordinates (rad, theta) or all three (rad, theta, z) as
+                        Scalars.
             derivs      True to propagate any derivatives inside pos and obs
                         into the returned coordinates.
-            hints       ignored.
+            hints       ignored. Provided for compatibility with other Surface
+                        subclasses.
 
         Return:         coordinate values packaged as a tuple containing two or
                         three Scalars, one for each coordinate.
@@ -173,21 +177,21 @@ class RingPlane(Surface):
 
         Input:
             coords      a tuple of two or three Scalars defining coordinates at
-                        or near this surface.
+                        or near this surface. These can have different shapes,
+                        but must be broadcastable to a common shape.
                 rad     mean orbital radius in the ring plane, in km.
                 theta   longitude in radians of the intercept point.
                 z       vertical distance in km above the ring plane.
             obs         a Vector3 of observer position relative to this
-                        surface's origin and frame. Ignored for solid surfaces.
-            time        a Scalar time at which to evaluate the surface.
+                        surface's origin and frame; ignored for this Surface
+                        subclass.
+            time        a Scalar time at which to evaluate the surface; ignored
+                        unless this RingPlane contains radial modes.
             derivs      True to propagate any derivatives inside the coordinates
                         and obs into the returned position vectors.
 
         Return:         a Vector3 of points defined by the coordinates, relative
                         to this surface's origin and frame.
-
-        Note that the coordinates can all have different shapes, but they must
-        be broadcastable to a single shape.
         """
 
         # Validate inputs
@@ -226,13 +230,16 @@ class RingPlane(Surface):
             derivs      True to propagate any derivatives inside obs and los
                         into the returned intercept point.
             guess       unused.
-            hints       unused.
+            hints       if not None (the default), this value is appended to the
+                        returned tuple. Needed for compatibility with other
+                        Surface subclasses.
 
-        Return:         a tuple (pos, t) where
+        Return:         a tuple (pos, t) or (pos, t, hints), where
             pos         a Vector3 of intercept points on the surface relative
                         to this surface's origin and frame, in km.
             t           a Scalar such that:
                             intercept = obs + t * los
+            hints       the input value of hints, included if hints is not None.
         """
 
         # Solve for obs + factor * los for scalar t, such that the z-component
@@ -266,7 +273,8 @@ class RingPlane(Surface):
         Input:
             pos         a Vector3 of positions at or near the surface relative
                         to this surface's origin and frame.
-            time        a Scalar time at which to evaluate the surface.
+            time        a Scalar time at which to evaluate the surface; ignored
+                        here.
             derivs      True to propagate any derivatives of pos into the
                         returned normal vectors.
 
@@ -298,7 +306,8 @@ class RingPlane(Surface):
         Input:
             pos         a Vector3 of positions at or near the surface relative
                         to this surface's origin and frame.
-            time        a Scalar time at which to evaluate the surface.
+            time        a Scalar time at which to evaluate the surface; ignored
+                        unless this RingPlane contains radial modes.
 
         Return:         a Vector3 of velocities, in units of km/s.
         """

--- a/oops/surface/spheroid.py
+++ b/oops/surface/spheroid.py
@@ -65,15 +65,16 @@ class Spheroid(Ellipsoid):
         Input:
             pos         a Vector3 of positions at or near the surface relative
                         to this surface's origin and frame.
-            time        a Scalar time at the surface; ignored here.
+            time        a Scalar time at which to evaluate the surface; ignored
+                        for this Surface subclass.
             direction   'arr' for a photon arriving at the surface; 'dep' for a
                         photon departing from the surface; ignored here.
             derivs      True to propagate derivatives in pos into the returned
                         intercepts.
-            guess       optional initial guess a coefficient array p such that:
+            guess       optional initial guess at coefficient array p such that
                             intercept + p * normal(intercept) = pos
                         Use guess=True for the converged value of p to be
-                        returned even if an initial guess was not provided.
+                        returned even if an initial guess is unavailable.
 
         Return:         intercept or (intercept, p).
             intercept   a vector3 of surface intercept points relative to this
@@ -160,7 +161,7 @@ class Spheroid(Ellipsoid):
         g0 = f1
 
         # Make an initial guess at p if necessary
-        if guess in (None, True):
+        if isinstance(guess, (type(None), bool, np.bool_)):
 
             # Unsquash into coordinates where the surface is a sphere
             pos_unsq = pos.wod.element_mul(self.unsquash)   # without derivs!


### PR DESCRIPTION
This should fix the bug where certain surface "hints" were being misinterpreted. Most of the changes are in docstrings to be much clearer about what's going on. I did identify a few other very minor bugs and fixed them as well. All unit tests pass. BTW, the lines that said `if hints in (None, True)` never worked correctly, because 1 == True and also Scalar(1) == True. The new test is ```isinstance(hints, (type(None), bool, np.bool_))``` which does the right thing, although it also means hints=False does the same thing as hints=True, which is probably OK. Also BTW, if you were unaware, np.bool_ is not a subclass of bool, which is annoying, so I include that because somebody might conceivably pass a numpy boolean array element as a hint, and we need that to work the same way as a bool. 