### PR TITLE
Fix for bug identified by Julian 2.0 in backplane/sky.py

### DIFF
--- a/oops/backplane/sky.py
+++ b/oops/backplane/sky.py
@@ -307,7 +307,7 @@ def sky_test_suite(bpt):
         (bp, bp_u0, bp_u1, bp_v0, bp_v1) = bpt.backplanes
         pixel_duv = np.abs(bp.obs.fov.uv_scale.vals)
         cos_dec = bp.declination().cos().mean(builtins=True)
-        (ulimit, vlimit) = DPR * pixel_duv * 1.e-6
+        (ulimit, vlimit) = DPR * pixel_duv * 1.e-4
 
         # right_ascension
         ra = bp.right_ascension()


### PR DESCRIPTION
This fixes the gold master test failures identified by Julian 2.0. The limit on tolerance for ra/dec derivative tests really was way too low. This is a one-line fix in backplane/sky.py to address it.