### PR TITLE
Remove Cassini ISS offset

### DIFF
--- a/oops/hosts/cassini/iss.py
+++ b/oops/hosts/cassini/iss.py
@@ -144,7 +144,7 @@ def from_index(filespec, **parameters):
     return snapshots
 
 #===============================================================================
-def initialize(ck='reconstructed', planets=None, offset_wac=True, asof=None,
+def initialize(ck='reconstructed', planets=None, offset_wac=False, asof=None,
                spk='reconstructed', gapfill=True,
                mst_pck=True, irregulars=True):
     """Initialize key information about the ISS instrument.

--- a/oops/hosts/juno/junocam/__init__.py
+++ b/oops/hosts/juno/junocam/__init__.py
@@ -120,7 +120,7 @@ def from_file(filespec, fast_distortion=True,
     return obs
 
 #===============================================================================
-def initialize(ck='reconstructed', planets=None, offset_wac=True, asof=None,
+def initialize(ck='reconstructed', planets=None, asof=None,
                spk='reconstructed', gapfill=True,
                mst_pck=True, irregulars=True):
     """Initialize key information about the JUNOCAM instrument.
@@ -134,8 +134,6 @@ def initialize(ck='reconstructed', planets=None, offset_wac=True, asof=None,
                     'none' if the kernels are to be managed manually.
         planets     A list of planets to pass to define_solar_system. None or
                     0 means all.
-        offset_wac  True to offset the WAC frame relative to the NAC frame as
-                    determined by star positions.
         asof        Only use SPICE kernels that existed before this date; None
                     to ignore.
         gapfill     True to include gapfill CKs. False otherwise.
@@ -145,7 +143,7 @@ def initialize(ck='reconstructed', planets=None, offset_wac=True, asof=None,
                     False otherwise.
     """
 
-    JUNOCAM.initialize(ck=ck, planets=planets, offset_wac=offset_wac, asof=asof,
+    JUNOCAM.initialize(ck=ck, planets=planets, asof=asof,
                    spk=spk, gapfill=gapfill,
                    mst_pck=mst_pck, irregulars=irregulars)
 


### PR DESCRIPTION
There is a NAC/WAC offset hard-coded in the Cassini ISS hosts module that I derived from previous navigation work, but I do not have confidence in this number or (based on information from Joe) the possibility that it might vary over time. Thus I'm turning it off by default until we can do further analysis. I think having the offset on by default will do more potential damage. I also removed the same copied code from JUNOCAM, even though that code is apparently never called. All tests still pass with current gold backplanes.

Fixes #96 