### PR TITLE
Fixed for UVIS and VIMS

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -4,3 +4,7 @@ coverage:
       default:
         # basic
         target: 0
+    patch:
+      default:
+        # basic
+        target: 0

--- a/oops/hosts/pds3.py
+++ b/oops/hosts/pds3.py
@@ -6,6 +6,7 @@
 ################################################################################
 import os
 import pdsparser
+import re
 from pathlib import Path
 
 #===============================================================================
@@ -64,6 +65,238 @@ def get_label(filespec, cleaner=None):
     # Parse the label into a dictionary
     return pdsparser.PdsLabel.from_string(lines).as_dict()
 
+#===============================================================================
+def pointer_int(value):
+    """Return the integer part of a PDS3 pointer in units of records.
+
+    Works whether or not as_dict() has been applied to the PdsLabel object.
+
+    ("v1793917030_1.qub", 47) -> 47
+    (47, 'RECORDS') -> 47
+    (47, 'BYTES') -> ValueError raised
+    47 -> 47
+    """
+
+    if isinstance(value, pdsparser.PdsLocalPointer):    # without as_dict()
+        return value.value
+
+    if isinstance(value, (list, tuple)):                # with as_dict()
+        if value[1] == 'BYTES':
+            raise ValueError('pointer has units of BYTES: ' + str(value))
+        return [v for v in value if isinstance(v, int)][0]
+
+    if isinstance(value, int):
+        return value
+
+    raise ValueError('not a valid pointer value: ' + str(value))
+
+#=========================================================================================
+def fast_dict(label, units=False, strings='concatenate'):
+    """Return a hierarchical dictionary containing the content of a PDS3 label.
+
+    This is _MUCH_ faster than pdsparser.PdsLabel.from_file (about 100x). However it does
+    almost no syntax checking and may not work on some labels that are otherwise PDS3
+    compliant.
+
+    Input:
+        label       a PDS3 label as a file path (string or pathlib object), string, or
+                    list of strings.
+        units       False to ignore units inside "<>" characters. True to include them, in
+                    which case a value with units is returned as a list with the unit
+                    string as the second value.
+        strings     how to handle extended strings within labels:
+            'indent'        preserve indents and newlines;
+            'newlines'      preserve newlines but not indents;
+            'concatenate'   concatenate into one string with single space separators.
+    """
+
+    def clean_lines(lines):
+        """Return a cleaned list of strings.
+
+        Remove blank lines and comments; strip final END; merge extended lists and strings
+        into a single line.
+        """
+
+        if strings not in {'concatenate', 'newlines', 'indent'}:
+            raise ValueError(f'invalid strings option: "{strings}"')
+
+        sep = ' ' if strings == 'concatenate' else '\n'
+
+        cleaned = []
+        prefix = ''
+        quote = ''
+        for line in lines:
+            line = line.partition('/*')[0]      # strip trailing comments
+
+            if strings == 'indent':
+                text = line.rstrip()
+                line = line.lstrip()
+            else:
+                line = line.strip()
+                text = line
+
+            # If we are currently inside a quoted string...
+            if quote:
+                quote_count = len([c for c in line if c == quote])
+                if quote_count % 2:     # if odd
+                    line = prefix + sep + text
+                    prefix = ''
+                    quote = ''
+                else:
+                    prefix += sep + text
+                    line = ''
+
+            if not line:
+                continue
+            if line.startswith('/*'):
+                continue
+            if line == 'END':
+                break
+
+            # Check for an unbalanced quote
+            for q in ('"', "'"):
+                quote_count = len([c for c in line if c == q])
+                if quote_count % 2:     # if odd
+                    prefix = line
+                    quote = q
+                    break
+
+            if quote:
+                continue
+
+            # Check for a continuation line
+            # This will fail if a comma is not the last char in an incomplete list
+            if line[-1] in (',', '='):
+                prefix = prefix + line
+                continue
+
+            # Otherwise, this line is complete
+            cleaned.append(prefix + line)
+            prefix = ''
+
+        if prefix:
+            cleaned.append(prefix)  # this will trigger an error in evaluate()
+
+        return cleaned
+
+    def evaluate(value):
+        """Evaluate one PDS3-compliant value. Lists and sets are supported."""
+
+        value = value.partition('/*')[0]
+        value = value.strip()
+
+        # Convert a set to a list
+        is_set = value[0] == '{'
+        if is_set:
+            if value[-1] != '}':
+                raise ValueError(f'unbalanced braces at "{value}"')
+            value = '(' + value[1:-1] + ')'
+
+        # Handle trailing units outside a list
+        if value.endswith('>'):
+            parts = value[:-1].partition('<')
+            if units:
+                value = '(' + parts[0] + ', "' + parts[-1] + '")'
+            else:
+                value = value.partition('<')[0].rstrip()
+
+        # Evaluate. We take advantage of the fact that most PDS3-compliant values are also
+        # Python-compliant.
+        try:
+            result = eval(value)
+        except Exception:
+            result = None
+
+        # If evaluation failed...
+        if result is None:
+
+            # If the value is inside parens, attempt each component separately
+            if value[0] == '(':
+                if value[-1] != ')':
+                    raise ValueError(f'unbalanced parentheses at "{value}"')
+
+                parts = re.split(''',(?=(?:[^'"]|'[^']*'|"[^"]*")*$)''', value[1:-1])
+                    # from https://stackoverflow.com/questions/2785755/...
+                    # ...how-to-split-but-ignore-separators-in-quoted-strings-in-python
+                return [evaluate(p) for p in parts]
+
+            # Otherwise, this is probably an unquoted string
+            result = value
+
+        # Otherwise, it's probably an un-quoted string
+
+        # Convert a tuple to a list
+        if isinstance(result, tuple):
+            result = list(result)
+
+        return result
+
+    def to_dict(lines):
+        """The dictionary from a "cleaned" list of records."""
+
+        state = [('', '', {})]         # list of (OBJECT or GROUP, name, dict)
+        for k, line in enumerate(lines):
+
+            # Get the name and value
+            (name, equal, value) = line.partition('=')
+            if not equal:
+                raise ValueError(f'missing "=" at "{line}"')
+
+            name = name.strip()
+            value = evaluate(value)
+
+            # If this begins an object, append it to the state list
+            if name in ('OBJECT', 'GROUP'):
+                state.append((name, value, {}))
+
+            # If this ends an object, add this sub-dictionary to the dictionary
+            elif name.startswith('END_'):
+                if not state:
+                    raise ValueError(f'unmatched {name} = {value}')
+
+                (obj_type, obj_name, obj_dict) = state.pop()
+                if obj_type != name[4:] or (value and value != obj_name):
+                    raise ValueError(f'unbalanced {obj_type} = {obj_name}')
+                        # tolerate END_OBJECT without name
+
+                state[-1][-1][obj_name] = obj_dict
+
+            # Otherwise, just append one new value to the current dictionary
+            else:
+                state[-1][-1][name] = value
+
+        # Make sure all objects and groups were terminated
+        (obj_type, obj_name, obj_dict) = state.pop()
+        if len(state) > 1:
+            raise ValueError(f'unbalanced {obj_type} = {obj_name}')
+
+        return obj_dict
+
+    #### Active code starts here
+
+    # Convert to a list of strings
+    if '\n' in label:                       # split a long string containing newlines
+        lines = label.split('\n')
+    elif isinstance(label, (str, Path)):    # read the content of a file path
+        with open(label, 'r', encoding='latin8') as f:
+            lines = f.readlines()
+    elif isinstance(label, list):           # leave a list alone
+        lines = label
+    else:
+        raise ValueError('not a recognized label')
+
+    cleaned = clean_lines(lines)
+    return to_dict(cleaned)
+
+# now = datetime.now()
+# for i in range(1000):
+#     x = fast_read(label)
+# datetime.now() - now
+#
+# now = datetime.now()
+# for i in range(10):
+#     x = pdsparser.PdsLabel.from_string(label)
+# datetime.now() - now
 
 ################################################################################
 # UNIT TESTS


### PR DESCRIPTION
These are fixes to UVIS and VIMS, sufficient to change the color code in Table 1, row 2 of Joe's proposal to green. There are still no unit tests but the obvious bugs were fixed and the modules now work fine according to my informal testing. They are certainly no worse than what was in there before today, so I hope they can be merged with minimal fuss.

One change that you may appreciate is that I added a new function fast_dict() in hosts/pds3. It does a quick parsing of a PDS3 label and returns a dictionary that is remarkably similar to what you expect from pdsparser.PdsLabel.from_file().as_dict(), but is 100 times faster. That's not a typo. It's a brute-force parser without using pyparsing, but not really all that complicated. It does no validation at all, so for that you still need pdsparser. There will probably be some edge cases where it can't read a label, but it appears to be quite robust in my testing so far. It is now the reader used for PDS3 labels in the VIMS and UVIS modules and it can handle the VIMS internal ISIS labels too.