### PR TITLE
Cleanup of error logging in gold_master.py and Galileo SSI

### DIFF
--- a/oops/config.py
+++ b/oops/config.py
@@ -139,6 +139,7 @@ class LOGGING(object):
     log_formatting = True           # True to use DEFAULT_LOG_FORMAT.
     warnings = 0                    # Warning count.
     errors = 0                      # Error count.
+    lines = 0                       # Number of lines logged.
     python_warnings = False         # Use Python warnings on LOGGING.warn()
 
     LEVELS = {                      # Static dictionary of logging levels
@@ -168,6 +169,7 @@ class LOGGING(object):
 
         LOGGING.warnings = 0
         LOGGING.errors = 0
+        LOGGING.lines = 0
 
     @staticmethod
     def all(flag, category='', reset=False):
@@ -210,8 +212,6 @@ class LOGGING(object):
         """Enable or disable log messages to stdout."""
 
         LOGGING.stdout = bool(flag)
-        LOGGING.errors = 0
-        LOGGING.warnings = 0
 
         if reset:
             LOGGING.reset()
@@ -221,9 +221,8 @@ class LOGGING(object):
         """Enable or disable log messages to stderr."""
 
         LOGGING.stderr = bool(flag)
-        LOGGING.errors = 0
-        LOGGING.warnings = 0
 
+        # Never allow stdout=False if other logging methods are off
         if not any([LOGGING._file, LOGGING.logger, LOGGING.stderr]):
             LOGGING.stdout = True
 
@@ -339,20 +338,21 @@ class LOGGING(object):
             level = LOGGING.LEVELS[level.lower()]
 
         # Update the prefix based on the level
-        if level >= logging.ERROR:
-            prefix = LOGGING.prefix + 'ERROR:'
-            LOGGING.errors += 1
-        elif level >= logging.WARNING:
-            prefix = LOGGING.prefix + 'WARNING:'
-            LOGGING.warnings += 1
-        else:
-            prefix = LOGGING.prefix
+        prefix = LOGGING.prefix
+        if not literal:
+            if level >= logging.ERROR:
+                prefix += 'ERROR:'
+                LOGGING.errors += 1
+            elif level >= logging.WARNING:
+                prefix += 'WARNING:'
+                LOGGING.warnings += 1
 
         # The Python warnings filter mechanism can be used, so a warning might
         # be suppressed or converted to an error. If suppressed, it will still
         # be sent to a logger.
         user_was_warned = False
-        if logging.WARNING <= level < logging.ERROR and LOGGING.python_warnings:
+        if (not literal and LOGGING.python_warnings
+                and logging.WARNING <= level < logging.ERROR):
             warnings.warn(' '.join([str(x) for x in args]))
             user_was_warned = True
 
@@ -362,7 +362,7 @@ class LOGGING(object):
             prefix_ = ''
 
         # Write to stdout
-        if LOGGING.stdout and not user_was_warned:
+        if LOGGING.stdout and level >= LOGGING.level and not user_was_warned:
             if prefix:
                 print(prefix, *args)
             else:
@@ -407,6 +407,8 @@ class LOGGING(object):
                 LOGGING.logger.log(LOGGING.level, message, extra=extras)
             else:
                 LOGGING.logger.log(level, message, extra=extras)
+
+        LOGGING.lines += (force or level >= LOGGING.level)
 
     @staticmethod
     def debug(*args, force=False):

--- a/oops/gold_master/__init__.py
+++ b/oops/gold_master/__init__.py
@@ -198,8 +198,8 @@ def set_default_obs(obspath, index, planets, moons=[], rings=[], kwargs={}):
                                    planets=planets, moons=moons, rings=rings,
                                    kwargs=kwargs)
 
-def define_standard_obs(obsname, obspath, index, planets, moons=[], rings=[],
-                        kwargs={}):
+def define_standard_obs(obsname, obspath, index=None, *, planets=[], moons=[],
+                        rings=[], kwargs={}):
     """Set the details of a standard gold master test.
 
     These are the observation file path and module to use when a test is
@@ -226,9 +226,12 @@ def define_standard_obs(obsname, obspath, index, planets, moons=[], rings=[],
 
     global STANDARD_OBS_INFO
 
-    planets = planets if isinstance(planets, (list,tuple)) else (planets,)
-    moons   = moons   if isinstance(moons,   (list,tuple)) else (moons,)
-    rings   = rings   if isinstance(rings,   (list,tuple)) else (rings,)
+    planets = (planets,) if isinstance(planets, str) else tuple(planets)
+    moons   = (moons,)   if isinstance(moons,   str) else tuple(moons)
+    rings   = (rings,)   if isinstance(rings,   str) else tuple(rings)
+
+    if not (planets or moons or rings):
+        raise ValueError('no planets, moons, or rings specified')
 
     STANDARD_OBS_INFO[obsname] = {}
     STANDARD_OBS_INFO[obsname]['obspath'] = obspath
@@ -550,7 +553,7 @@ def execute_as_command():
                     help='Do not write a log file in the output directory%s.'
                          % ('' if DEFAULTS['log'] else ' (default)'))
     gr.add_argument('--level', type=str, metavar='LEVEL',
-                    choices=['debug', 'warning', 'error']
+                    choices=['debug', 'info', 'warning', 'error']
                             + [str(k) for k in range(1,31)],
                     default=DEFAULTS['level'],
                     help='''Minimum level for messages to be logged: "debug",
@@ -791,16 +794,41 @@ def run_tests(args):
     LOGGING.all(args.convergence, category='convergence')
     LOGGING.all(args.diagnostics, category='diagnostics')
     LOGGING.all(args.performance, category='performance')
+    LOGGING.reset()
 
-    LOGGING.reset()         # zero out error and warning counts
     errors = 0
+    warnings = 0
+    lines = 0
     had_exception = False
+    start = datetime.datetime.now()
     try:
-        for bpt in args.backplane_tests:
-            errors += bpt.run_tests()
+        for k, bpt in enumerate(args.backplane_tests):
+
+            # Insert blank line after tests that logged something/anything
+            if LOGGING.lines:
+                LOGGING.literal(level=args.level, force=True)
+
+            LOGGING.reset()         # zero out error and warning counts
+            bpt.run_tests()
+
+            errors += LOGGING.errors
+            warnings += LOGGING.warnings
+            lines += LOGGING.lines
+
     except Exception as e:
         LOGGING.exception(e)
         had_exception = True
+
+    finally:
+        if len(args.backplane_tests) > 0:
+            if LOGGING.lines:
+                LOGGING.literal(level=args.level, force=True)
+
+            LOGGING.info('Total warnings = ' + str(warnings))
+            LOGGING.info('Total errors = ' + str(errors))
+
+            seconds = (datetime.datetime.now() - start).total_seconds()
+            LOGGING.info('Total elapsed time: %.3f s' % seconds)
 
     if errors or had_exception > 0:
         if args.testcase is not None:
@@ -1088,6 +1116,13 @@ class BackplaneTest(object):
         self.summary = {}
         self.results = {}
 
+        # Prepare to log observation info before the first warning or error if
+        # the logging level is > INFO.
+        self.header = ['File: ' + self.abspath]
+        if self.suffix:
+            self.header.append('Suffix: ' + self.suffix)
+        self.print_header = self.args.level > logging.INFO
+
     ############################################################################
     # Test runner for one BackplaneTest
     ############################################################################
@@ -1110,12 +1145,12 @@ class BackplaneTest(object):
         self.results = {}
 
         # Set up the log handler; set aside any old log
-        # Note that each BackplaneTest gets its own dedicated logger
-        LOGGING.push()
+        # Note that each BackplaneTest gets its own dedicated log file.
         if self.args.log:
             # Make sure the output directory exits
             os.makedirs(self.output_dir, exist_ok=True)
 
+            # Relocate any pre-existing log for this observation
             log_path = os.path.join(self.output_dir, self.task + '.log')
             if os.path.exists(log_path):
                 timestamp = os.path.getmtime(log_path)
@@ -1129,12 +1164,16 @@ class BackplaneTest(object):
 
         # Run the tests
         start = datetime.datetime.now()
-        try:
-            LOGGING.info('Beginning task ' + self.task)
-            LOGGING.info('File: ' + self.abspath)
-            if self.suffix:
-                LOGGING.info('Suffix: ' + self.suffix)
 
+        LOGGING.info('Beginning task ' + self.task)
+        for msg in self.header:
+            LOGGING.info(msg)
+        self.print_header = self.args.level > logging.INFO
+            # This flag indicates that we must print the observation info just
+            # before the first warning or error. Otherwise, we don't know which
+            # observation triggered it.
+
+        try:
             # Make sure test data and gold master files exist
             if self.task in ('compare', 'adopt'):
                 if not OOPS_GOLD_MASTER_PATH:
@@ -1205,84 +1244,82 @@ class BackplaneTest(object):
 
             # Internals...
             if self.args.internals:
+
+                # Temporarily set the logging level to DEBUG
                 LOGGING.push()
-                LOGGING.set_logger_level('DEBUG')
-                bp = self.backplane
+                try:
+                    LOGGING.set_logger_level('DEBUG')
+                    bp = self.backplane
 
-                for i in (False, True):
-                    LOGGING.diagnostic('\nSurface Events, derivs=%s' % i)
-                    keys = list(bp.surface_events[i].keys())
-                    keys.sort()
-                    for key in keys:
-                        sum = np.sum(bp.surface_events[i][key].mask)
-                        LOGGING.diagnostic('   ', key, sum)
+                    for i in (False, True):
+                        LOGGING.diagnostic('\nSurface Events, derivs=%s' % i)
+                        keys = list(bp.surface_events[i].keys())
+                        keys.sort()
+                        for key in keys:
+                            sum = np.sum(bp.surface_events[i][key].mask)
+                            LOGGING.diagnostic('   ', key, sum)
 
-                for i in (False, True):
-                    LOGGING.diagnostic('\nIntercepts, derivs=%s' % i)
-                    keys = list(bp.intercepts[i].keys())
+                    for i in (False, True):
+                        LOGGING.diagnostic('\nIntercepts, derivs=%s' % i)
+                        keys = list(bp.intercepts[i].keys())
+                        keys.sort(key=BackplaneTest._sort_key)
+                        for key in keys:
+                            sum = np.sum(bp.intercepts[i][key].mask)
+                            LOGGING.diagnostic('   ', key, sum)
+
+                    LOGGING.diagnostic('\nGridless arrivals')
+                    keys = list(bp.gridless_arrivals.keys())
                     keys.sort(key=BackplaneTest._sort_key)
                     for key in keys:
-                        sum = np.sum(bp.intercepts[i][key].mask)
+                        sum = np.sum(bp.gridless_arrivals[key].mask)
                         LOGGING.diagnostic('   ', key, sum)
 
-                LOGGING.diagnostic('\nGridless arrivals')
-                keys = list(bp.gridless_arrivals.keys())
-                keys.sort(key=BackplaneTest._sort_key)
-                for key in keys:
-                    sum = np.sum(bp.gridless_arrivals[key].mask)
-                    LOGGING.diagnostic('   ', key, sum)
+                    LOGGING.diagnostic('\nBackplanes')
+                    keys = list(bp.backplanes.keys())
+                    keys.sort(key=BackplaneTest._sort_key)
+                    for key in keys:
+                        sum = np.sum(bp.backplanes[key].mask)
+                        if key in bp.backplanes_with_derivs:
+                            derivs = bp.backplanes_with_derivs[key].derivs
+                            flag = ' '
+                            if 't' in derivs:
+                                if 'los' in derivs:
+                                    flag = '*'
+                                else:
+                                    flag = 't'
+                            elif 'los' in derivs:
+                                flag = 'l'
+                        else:
+                            flag = ' '
+                        LOGGING.diagnostic('   %s%s' % (flag, key), sum)
 
-                LOGGING.diagnostic('\nBackplanes')
-                keys = list(bp.backplanes.keys())
-                keys.sort(key=BackplaneTest._sort_key)
-                for key in keys:
-                    sum = np.sum(bp.backplanes[key].mask)
-                    if key in bp.backplanes_with_derivs:
-                        derivs = bp.backplanes_with_derivs[key].derivs
-                        flag = ' '
-                        if 't' in derivs:
-                            if 'los' in derivs:
-                                flag = '*'
-                            else:
-                                flag = 't'
-                        elif 'los' in derivs:
-                            flag = 'l'
-                    else:
-                        flag = ' '
-                    LOGGING.diagnostic('   %s%s' % (flag, key), sum)
+                    LOGGING.diagnostic('\nAntimasks')
+                    keys = list(bp.antimasks.keys())
+                    keys.sort()
+                    for key in keys:
+                        antimask = bp.antimasks[key]
+                        info = ('array' if isinstance(antimask, np.ndarray)
+                                        else str(antimask))
+                        LOGGING.diagnostic('   ', key, '(%s)' % info)
 
-                LOGGING.diagnostic('\nAntimasks')
-                keys = list(bp.antimasks.keys())
-                keys.sort()
-                for key in keys:
-                    antimask = bp.antimasks[key]
-                    info = ('array' if isinstance(antimask, np.ndarray)
-                                    else str(antimask))
-                    LOGGING.diagnostic('   ', key, '(%s)' % info)
+                    LOGGING.diagnostic()
 
-                LOGGING.diagnostic()
-                errors = LOGGING.errors
-                LOGGING.pop()
+                finally:
+                    LOGGING.pop()
+
+        # Summarize; be sure to remove any BackplaneTest-specific file handler
+        finally:
+            LOGGING.info('Warnings = ' + str(LOGGING.warnings))
+            LOGGING.info('Errors = ' + str(LOGGING.errors))
 
             seconds = (datetime.datetime.now() - start).total_seconds()
             LOGGING.info('Elapsed time: %.3f s' % seconds)
-
-        # Be sure to remove the BackplaneTest-specific file handler afterward
-        finally:
-            if LOGGING.warnings:
-                LOGGING.debug('Total warnings = ' + str(LOGGING.warnings))
-            if LOGGING.errors:
-                LOGGING.info('Total errors = ' + str(LOGGING.errors),
-                             force=True)
 
             if self.args.log:
                 LOGGING.logger.removeHandler(handler)
                 handler.close()
 
-            errors = LOGGING.errors
-            LOGGING.pop()
-
-        return errors
+        return
 
     @staticmethod
     def _sort_key(key):
@@ -1959,7 +1996,7 @@ class BackplaneTest(object):
         """Log this comparison info.
 
         A single record of the log file has this format:
-          "<time> | oops.backplane.gold_master | <level> | <suite> | <message>"
+          "<time> | oops.gold_master | <level> | <suite> | <message>"
         where
           <time>  is the local time to the level of ms.
           <level> is one of "DEBUG", "INFO", "WARNING", "ERROR", "FATAL".
@@ -2054,6 +2091,12 @@ class BackplaneTest(object):
                 message += ['/', str(errors2)]
 
             message += ['/', str(comparison.pixels)]
+
+        # If necessary, print the observation info before the first error
+        if comparison.status != 'Success' and self.print_header:
+            for msg in self.header:
+                LOGGING.info(msg, force=True)
+            self.print_header = False
 
         LOGGING.print(''.join(message), level=comparison.logging_level)
 

--- a/oops/hosts/galileo/ssi/__init__.py
+++ b/oops/hosts/galileo/ssi/__init__.py
@@ -40,7 +40,7 @@ def from_file(filespec,
     label = pds3.get_label(filespec)
 
     # Load the data array
-    vic = vicar.VicarImage.from_file(filespec, extraneous='warn')
+    vic = vicar.VicarImage.from_file(filespec)
     vicar_dict = vic.as_dict()
 
     # Get image metadata

--- a/tests/hosts/galileo/ssi/standard_obs.py
+++ b/tests/hosts/galileo/ssi/standard_obs.py
@@ -17,12 +17,9 @@ name = 'C0349632100R'
 #  python gold_master.py --name C0349632100R --adopt
 
 gm.define_standard_obs(name,
-        obspath = os.path.join(TESTDATA_PARENT_DIRECTORY,
-                               'galileo/GO_0017/G1/GANYMEDE/' + name + '.img'),
-        index    = None,
-        planets  = '',
-        moons    = 'GANYMEDE',
-        rings    = '')
+        obspath=os.path.join(TESTDATA_PARENT_DIRECTORY,
+                             'galileo/GO_0017/G1/GANYMEDE/' + name + '.img'),
+        moons='GANYMEDE')
 
 gm.override('Right ascension d/dv self-check (deg/pix)', 2.2e-9, names=name)
 
@@ -36,8 +33,6 @@ gm.override('GANYMEDE center declination (deg, apparent)', 2e-4, names=name)
 gm.override('GANYMEDE center distance to observer (km)', 3., names=name)
 gm.override('GANYMEDE center light time to observer (km)', 9e-6, names=name)
 
-
-
 ###################################################################
 name = 'C0368369200R'
 ###################################################################
@@ -48,10 +43,7 @@ name = 'C0368369200R'
 gm.define_standard_obs(name,
         obspath = os.path.join(TESTDATA_PARENT_DIRECTORY,
                                'galileo/GO_0017/C3/JUPITER/' + name + '.img'),
-        index    = None,
-        planets  = '',
-        moons    = 'JUPITER',
-        rings    = '')
+        planets='JUPITER')
 
 gm.override('JUPITER:RING longitude d/du self-check (deg/pix)', .00025, names=name)
 gm.override('JUPITER:RING longitude d/dv self-check (deg/pix)', .00014, names=name)
@@ -77,34 +69,9 @@ name = 'C0061455700R'
 #  python gold_master.py --name C0061455700R --adopt
 
 gm.define_standard_obs(name,
-        obspath = os.path.join(TESTDATA_PARENT_DIRECTORY,
-                               'galileo/GO_0004/EARTH/' + name + '.img'),
-        index    = None,
-        planets  = '',
-        moons    = 'EARTH',
-        rings    = '')
-
-# overrides to cover unexplained discrepancies among Mark, Rob, Joe
-gm.override('EUROPA center distance from Sun (km)', 5., names=name)
-gm.override('EUROPA center light time from Sun (km)', 1.5e-5, names=name)
-gm.override('EUROPA pole clock angle (deg)', 0.0017, names=name)
-gm.override('EUROPA pole position angle (deg)', 0.0017, names=name)
-gm.override('EUROPA center right ascension (deg, actual)', 0.007, names=name)
-gm.override('EUROPA center right ascension (deg, apparent)', 0.007, names=name)
-gm.override('EUROPA center declination (deg, actual)', 0.017, names=name)
-gm.override('EUROPA center declination (deg, apparent)', 0.017, names=name)
-gm.override('EUROPA sub-observer latitude, planetocentric (deg)', 0.019, names=name)
-gm.override('EUROPA sub-observer latitude, planetographic (deg)', 0.019, names=name)
-
-# These overrides are only necessary for Windows; I don't know why.  --Mark
-# (The default error threshold is 0.001.)
-gm.override('EUROPA center phase angle, apparent (deg)', 0.0015, names=name)
-gm.override('EUROPA center phase angle, actual (deg)', 0.0015, names=name)
-gm.override('EUROPA orbit longitude wrt observer (deg)', 0.0015, names=name)
-gm.override('EUROPA orbit longitude wrt OHA (deg)', 0.0015, names=name)
-gm.override('EUROPA sub-observer longitude, IAU (deg)', 0.0015, names=name)
-gm.override('EUROPA sub-observer longitude wrt Sun (deg)', 0.0015, names=name)
-gm.override('EUROPA sub-solar longitude wrt observer (deg)', 0.0015, names=name)
+        obspath=os.path.join(TESTDATA_PARENT_DIRECTORY,
+                             'galileo/GO_0004/EARTH/' + name + '.img'),
+        planets='EARTH')
 
 ###################################################################
 name = 'C0374685140R'
@@ -114,12 +81,9 @@ name = 'C0374685140R'
 #  python gold_master.py --name C0374685140R --adopt
 
 gm.define_standard_obs(name,
-        obspath = os.path.join(TESTDATA_PARENT_DIRECTORY,
-                               'galileo/GO_0017/E4/EUROPA/' + name + '.img'),
-        index    = None,
-        planets  = '',
-        moons    = 'EUROPA',
-        rings    = '')
+        obspath=os.path.join(TESTDATA_PARENT_DIRECTORY,
+                             'galileo/GO_0017/E4/EUROPA/' + name + '.img'),
+        moons='EUROPA')
 
 # overrides to cover unexplained discrepancies among Mark, Rob, Joe
 gm.override('EUROPA center distance from Sun (km)', 5., names=name)


### PR DESCRIPTION
This pull request contains fixes to how errors are logged. It was part of the previous pull request but that one got merged before I had pushed these changes.

In the LOGGING methods in `oops/config.py`:
* Add counter that records how many lines a logger has printed.
* In `print()`, literal messages no longer get counted as warnings or errors, even if the level is WARN or ERROR. This is consistent with the point of literal messages, which is to add supplementary info to the log. Supplementary info about a warning or error should not increment the count.

In `oops/gold_master/__init__.py`:
* Add sensible default values to `define_standard_obs()`.
* Force the planets, moons, and rings inputs to be tuples, never lists.
* Bugfix: "info" was not a recognized input for --level.
* Force a log message to be printed identifying the observation in which an error is logged. Previously, if the logging level was set to something higher than INFO and the test was being run on multiple observations, an error would be logged without identifying which of multiple observations triggered the error.
* There is now a blank line in the log between multiple observations tested when the level is INFO.
* When multiple observations were tested, the log ends with INFO messages indicating the total warnings, total errors, and total elapsed time.
* When logging internals, I now ensure that `LOGGING.pop()` is always called after `LOGGING.push()` using try/finally.

For Galileo SSI:
* I removed the "extraneous byte" warning because it seems to be a common issue in the data files and we really don't care.
* I simplified the calls to `define_standard_obs()`, taking advantage of the new input defaults.