### PR TITLE
Make GCP standard for testing

### DIFF
--- a/.github/workflows/run-tests-dropbox.yml
+++ b/.github/workflows/run-tests-dropbox.yml
@@ -1,27 +1,28 @@
 name: Test oops
-run-name: "Run Tests: ${{ github.ref_type }} ${{ github.ref_name }} by ${{ github.triggering_actor }}"
+run-name: "Run Tests (Dropbox): ${{ github.ref_type }} ${{ github.ref_name }} by ${{ github.triggering_actor }}"
 
 on:
   workflow_dispatch:
-  pull_request:
-    branches: [ main ]
-  push:
-    branches: [ main ]
-  schedule:
-    - cron: "00 09 * * *"   # 1am PST, 2am PDT
 
 jobs:
   test:
-    name: Test oops
+    name: Test oops with Dropbox
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        # MacOS: Python 3.8-3.10 does not currently work on MacOS.
+        include:
+          - os: self-hosted-linux
+            python-version: "3.9"
+          - os: self-hosted-linux
+            python-version: "3.13"
+          - os: self-hosted-macos
+            python-version: "3.13"
+          - os: self-hosted-windows
+            python-version: "3.9"
+          - os: self-hosted-windows
+            python-version: "3.13"
       fail-fast: false
-    permissions:
-      contents: read
-      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -35,7 +36,6 @@ jobs:
 
       - name: Test with coverage
         run: |
-          export OOPS_RESOURCES=gs://rms-node-oops-resources
           scripts/automated_tests/oops_main_test.sh
         shell: bash
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,7 +8,7 @@ on:
   push:
     branches: [ main ]
   schedule:
-    - cron: "00 09 * * *"   # 1am PST, 2am PDT
+    - cron: "21 11 * * 0"
 
 jobs:
   test:
@@ -32,6 +32,12 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          project_id: rms-node
+          workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
 
       - name: Test with coverage
         run: |

--- a/scripts/automated_tests/oops_main_test.sh
+++ b/scripts/automated_tests/oops_main_test.sh
@@ -1,17 +1,12 @@
 #!/bin/bash
 
-source ~/oops_runner_secrets
-if [ $? -ne 0 ]; then exit -1; fi
+# Only read in the standard OOPS_RESOURCES if it isn't already in the
+# environment
+if [[ -z ${OOPS_RESOURCES+x} ]]; then
+    source ~/oops_runner_secrets
+    if [ $? -ne 0 ]; then exit -1; fi
+fi
 
-# Can't use -v because it doesn't work on MacOS
-if [[ -z ${SPICE_PATH+x} ]]; then
-    echo "SPICE_PATH is not set"
-    exit -1
-fi
-if [[ -z ${SPICE_SQLITE_DB_NAME+x} ]]; then
-    echo "SPICE_SQLITE_DB_NAME is not set"
-    exit -1
-fi
 if [[ -z ${OOPS_RESOURCES+x} ]]; then
     echo "OOPS_RESOURCES is not set"
     exit -1


### PR DESCRIPTION
With these changes, there are now two test suites.

The default suite in `run-tests.yml` (which is run during pull requests and merges as well as weekly) uses the GCP bucket `rms-node-oops-resources` for accessing SPICE kernels and golden test files. This allows us to run lots of combinations of Python version and OS because they can run on the GitHub-hosted runners.

The second suite in `run-tests-dropbox.yml` (which can be run manually via the Actions tab) uses the Dropbox contents and runs on our self-hosted runner. This means we run many fewer combinations, because we have limited resources and don't want them to take a long time.

Whenever the OOPS Dropbox is updated, it should be synced with the `rms-node-oops-resources` bucket to allow the tests to run. This doesn't happen very often at the moment, but we should eventually make it automatic.