### PR TITLE
Hacks to fix hosts for navigation work

### DIFF
--- a/oops/hosts/cassini/iss.py
+++ b/oops/hosts/cassini/iss.py
@@ -39,7 +39,7 @@ def from_file(filespec, fast_distortion=True,
     # Load the VICAR file
     filespec = FCPath(filespec)
     local_path = filespec.retrieve()
-    vic = vicar.VicarImage.from_file(local_path)
+    vic = vicar.VicarImage.from_file(local_path, strict=False)
     vicar_dict = vic.as_dict()
 
     # Get key information from the header
@@ -294,7 +294,7 @@ class ISS(object):
 
     #===========================================================================
     @staticmethod
-    def initialize(ck='reconstructed', planets=None, offset_wac=True, asof=None,
+    def initialize(ck='reconstructed', planets=None, offset_wac=False, asof=None,
                    spk='reconstructed', gapfill=True,
                    mst_pck=True, irregulars=True):
         """Initialize key information about the ISS instrument.

--- a/oops/hosts/newhorizons/lorri.py
+++ b/oops/hosts/newhorizons/lorri.py
@@ -320,10 +320,10 @@ def from_file(filespec, geom='spice', pointing='spice', fov_type='fast',
             point_factor = (1. / texp / spectral_irradiance / fov.uv_area *
                             np.pi * solar_range**2 / F_solar)
 
-            extended_calib[spectral_name] = oops.calib.ExtendedSource('I/F',
-                                                            extended_factor)
-            point_calib[spectral_name] = oops.calib.PointSource('I/F',
-                                                            point_factor, fov)
+            # TODO extended_calib[spectral_name] = oops.calib.ExtendedSource('I/F',
+            #                                                 extended_factor)
+            # point_calib[spectral_name] = oops.calib.PointSource('I/F',
+            #                                                 point_factor, fov)
 
         snapshot.insert_subfield('point_calib', point_calib)
         snapshot.insert_subfield('extended_calib', extended_calib)

--- a/oops/hosts/newhorizons/lorri.py
+++ b/oops/hosts/newhorizons/lorri.py
@@ -304,29 +304,29 @@ def from_file(filespec, geom='spice', pointing='spice', fov_type='fast',
         extended_calib = {}
         point_calib = {}
 
-        for spectral_name in ['SOLAR', 'PLUTO', 'PHOLUS', 'CHARON', 'JUPITER']:
+        # for spectral_name in ['SOLAR', 'PLUTO', 'PHOLUS', 'CHARON', 'JUPITER']:
 
-            # Extended source
-            spectral_radiance = header['R' + spectral_name]
+        #     # Extended source
+        #     spectral_radiance = header['R' + spectral_name]
 
-            # Point source
-            spectral_irradiance = header['P' + spectral_name]
+        #     # Point source
+        #     spectral_irradiance = header['P' + spectral_name]
 
-            F_solar = 176.  # pivot 6076.2 A at 1 AU
+        #     F_solar = 176.  # pivot 6076.2 A at 1 AU
 
-            # Conversion to I/F
-            extended_factor = (1. / texp / spectral_radiance * np.pi *
-                               solar_range**2 / F_solar)
-            point_factor = (1. / texp / spectral_irradiance / fov.uv_area *
-                            np.pi * solar_range**2 / F_solar)
+        #     # Conversion to I/F
+        #     extended_factor = (1. / texp / spectral_radiance * np.pi *
+        #                        solar_range**2 / F_solar)
+        #     point_factor = (1. / texp / spectral_irradiance / fov.uv_area *
+        #                     np.pi * solar_range**2 / F_solar)
 
-            # TODO extended_calib[spectral_name] = oops.calib.ExtendedSource('I/F',
-            #                                                 extended_factor)
-            # point_calib[spectral_name] = oops.calib.PointSource('I/F',
-            #                                                 point_factor, fov)
+        #     # TODO extended_calib[spectral_name] = oops.calib.ExtendedSource('I/F',
+        #     #                                                 extended_factor)
+        #     # point_calib[spectral_name] = oops.calib.PointSource('I/F',
+        #     #                                                 point_factor, fov)
 
-        snapshot.insert_subfield('point_calib', point_calib)
-        snapshot.insert_subfield('extended_calib', extended_calib)
+        # snapshot.insert_subfield('point_calib', point_calib)
+        # snapshot.insert_subfield('extended_calib', extended_calib)
 
     if include_headers:
         headers = []

--- a/oops/hosts/voyager/iss.py
+++ b/oops/hosts/voyager/iss.py
@@ -109,7 +109,8 @@ def from_file(filespec, astrometry=False, action='error', parameters={}):
         factor = None
 
     # Interpret the GEOMED parameter
-    if 'GEOMA' in vic['TASK']:
+    if 'GEOM' in imagespec.name:
+    # if 'GEOMA' in vic['TASK']:
         assert vic.data_2d.shape == (1000,1000)
         fovs = {
             'NAC': ISS.fovs['NAC_GEOMED'],

--- a/oops/hosts/voyager/iss.py
+++ b/oops/hosts/voyager/iss.py
@@ -181,9 +181,9 @@ def from_file(filespec, astrometry=False, action='error', parameters={}):
                                planet = planet,
                                target = target)
 
-    if factor is not None:
-        result.insert_subfield('extended_calib',
-                               oops.calib.ExtendedSource('I/F', factor))
+    # TODO if factor is not None:
+    #     result.insert_subfield('extended_calib',
+    #                            oops.calib.ExtendedSource('I/F', factor))
 
     return result
 


### PR DESCRIPTION
These changes are required to make the hosts module not crash and/or just work for my navigation project. In most cases bad code is simply commented out and will need to be replaced with the correct code.

- Cassini ISS:
  - Turn off strict VICAR label processing.
  - Turn off NAV/WAC offset since this is left over from the old navigation project and is probably wrong.
- NH LORRI:
  - Comment out all code related to calibration. This is for two reasons: 1) the oops calibration classes have changed, and 2) the spectral headers like `RSOLAR` don't actually seem to be in the FITS header.
- Voyager ISS:
  - Comment out all code related to calibration. This is because the oops calibration classes have changed.
  - Work around a bug in the `vicar` library where the "TASK" label value is incorrect.
