### PR TITLE
Minor bugfixes and features needed by Mark

### DIFF
--- a/oops/hosts/hst/__init__.py
+++ b/oops/hosts/hst/__init__.py
@@ -538,6 +538,9 @@ class HST(object):
         if include_headers:
             snapshot.insert_subfield('headers', self.get_headers(hdulist, **parameters))
 
+        model = parameters.get('solar_model', 'STIS')
+        snapshot.insert_subfield('bandpass', self.bandpass(hdulist, model=model,
+                                                           **parameters))
         return snapshot
 
     ######################################################################################
@@ -905,6 +908,13 @@ class HST(object):
                                                             sun_range=sun_range)
 
         return solar_f_mks_per_micron * solar.TO_CGS * solar.TO_PER_ANGSTROM
+
+    def bandpass(self, hdulist, model='STIS', **parameters):
+        bandpass_ = self.load_syn_throughput(hdulist, **parameters)
+        bandpass_ = tab.Tabulation(bandpass_.x * 1.e-4, bandpass_.y)
+
+        sun = solar.flux_density(model=model, units='W/m^2/um', xunits='um')
+        return sun * bandpass_
 
     def compare_pivot_mean(self, hdulist):
         """A tuple containing the pivot wavelength as derived from the SYN file

--- a/oops/path/linearcoordpath.py
+++ b/oops/path/linearcoordpath.py
@@ -30,6 +30,11 @@ class LinearCoordPath(Path):
                         leave the path unregistered.
         """
 
+        if self.surface.IS_VIRTUAL:
+            raise NotImplementedError('LinearCoordPath cannot be defined for '
+                                      'virtual surface class '
+                                      + type(self.surface).__name__)
+
         self.surface = surface
         self.coords = [Scalar.as_scalar(c) for c in coords]
         self.coords_dot = [Scalar.as_scalar(c) for c in coords_dot]
@@ -74,14 +79,7 @@ class LinearCoordPath(Path):
             new_coords.append(coord)
 
         new_coords = tuple(new_coords)
-
-        if self.surface.IS_VIRTUAL:
-            obs = self.obs_path.event_at_time(time, quick=quick).pos
-        else:
-            obs = None
-
-        pos = self.surface.vector3_from_coords(new_coords, obs, derivs=True)
-
+        pos = self.surface.vector3_from_coords(new_coords, derivs=True)
         return Event(time, pos, self.origin, self.frame)
 
 ################################################################################

--- a/oops/path/multipath.py
+++ b/oops/path/multipath.py
@@ -15,7 +15,7 @@ class MultiPath(Path):
     PATH_IDS = {}
 
     #===========================================================================
-    def __init__(self, paths, origin=None, frame=None, path_id='+',
+    def __init__(self, paths, origin=None, frame=None, path_id=None,
                        unpickled=False):
         """Constructor for a MultiPath Path.
 

--- a/oops/surface/ansa.py
+++ b/oops/surface/ansa.py
@@ -104,6 +104,23 @@ class Ansa(Surface):
                     ringplane=ringplane, radii=ringplane.radii)
 
     #===========================================================================
+    @staticmethod
+    def for_body(body):
+        """Construct an Ansa Surface associated with a given body, ignoring any
+        modes.
+
+        Input:
+            body        a ring body to which this ansa surface is to be defined.
+        """
+
+        # Identify the ring body
+        if body.surface.COORDINATE_TYPE != 'polar':
+            body = body.ring_body
+
+        return Ansa(body.path, body.frame, gravity=body.gravity,
+                    ringplane=body.surface, radii=body.surface.radii)
+
+    #===========================================================================
     def coords_from_vector3(self, pos, obs=None, time=None, axes=2,
                                   derivs=False, hints=None):
         """Surface coordinates associated with a position vector.

--- a/tests/path/test_multipath.py
+++ b/tests/path/test_multipath.py
@@ -31,7 +31,7 @@ class Test_MultiPath(unittest.TestCase):
         earth = SpicePath("EARTH", "SSB")
         moon  = SpicePath("MOON", "EARTH")
 
-        test = MultiPath([sun,earth,moon], "SSB")
+        test = MultiPath([sun,earth,moon], "SSB", path_id='+')
 
         self.assertEqual(test.path_id, "SUN+others")
         self.assertEqual(test.shape, (3,))


### PR DESCRIPTION
- Addresses issue #92. The simple fix is to change the default value of path_id from "+" to None, which now matches the behavior of other Path subclasses. As long as a Path has no ID, it is unregistered and the problem goes away. The default value of the path_id was a relic from the past. It's still true that `path_id='+'` will generate a non-specific path ID, but presumably the user knows what they're doing.
- New function `Ansa.for_body()` creates an Ansa surface for the associated body, similar to `Ansa.for_ringplane()`.
- `CoordPath` and `LinearCoordPath` are classes that let you define a Path object based on a Surface and defined coordinate values. This feature interacts very poorly with "virtual" surfaces, such as Limb and Ansa. Now the attempt to construct one of these Paths on a virtual Surface raises a `NotImplementedError`.
- I needed an HST Observation object to have an attribute "bandpass", which contains a tabulation of the filter bandpass. Eventually this should be implemented for other host modules, but for now this meets my needs.