### PR TITLE
LORRI bounding box v coordinates reversed

### DIFF
--- a/oops/backplane/limb.py
+++ b/oops/backplane/limb.py
@@ -18,7 +18,7 @@ def limb_altitude(self, event_key, zmin=None, zmax=None, scaled=False):
 
     Input:
         event_key       key defining the limb surface event.
-        zmin            lower limit on altitude; smaller values are masked.
+        zmin            lower limit on altitude; lower values are masked.
         zmax            upper limit on altitude.
         scaled          if True, zmin and zmax are in units of the maximum body radius.
     """

--- a/oops/backplane/limb.py
+++ b/oops/backplane/limb.py
@@ -18,7 +18,7 @@ def limb_altitude(self, event_key, zmin=None, zmax=None, scaled=False):
 
     Input:
         event_key       key defining the limb surface event.
-        zmin            lower limit on altitude; lower values are masked.
+        zmin            lower limit on altitude; smaller values are masked.
         zmax            upper limit on altitude.
         scaled          if True, zmin and zmax are in units of the maximum body radius.
     """

--- a/oops/observation/snapshot.py
+++ b/oops/observation/snapshot.py
@@ -550,7 +550,7 @@ class Snapshot(Observation):
         returned_dict = {}
 
         u_scale = fov.uv_scale.vals[0]
-        v_scale = fov.uv_scale.vals[1]
+        v_scale = np.abs(fov.uv_scale.vals[1])
         body_uv = fov.uv_from_los_t(arrival_event.neg_arr_ap,
                                     time=obs_time).vals
         for i in range(nbodies):


### PR DESCRIPTION
resolves #153
 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This PR fixes an issue with bounding box coordinate calculation by applying absolute value to ensure non-negative v coordinates. The change enhances reliability of coordinate computations and resolves the erroneous reversal of v coordinates previously observed.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>