### PR TITLE
Early Cassini ISS images can not be read

### DIFF
--- a/oops/hosts/cassini/iss.py
+++ b/oops/hosts/cassini/iss.py
@@ -43,17 +43,19 @@ def from_file(filespec, fast_distortion=True,
     vicar_dict = vic.as_dict()
 
     # Get key information from the header
-    tstart = julian.tdb_from_tai(julian.tai_from_iso(vic['START_TIME']))
+    tstop = julian.tdb_from_tai(julian.tai_from_iso(vic['IMAGE_TIME']))
     texp = max(1.e-3, vicar_dict['EXPOSURE_DURATION']) / 1000.
+    tstart = tstop - 0.5*texp
     mode = vicar_dict['INSTRUMENT_MODE_ID']
 
-    name = vicar_dict['INSTRUMENT_NAME']
-    if 'WIDE' in name:
-        camera = 'WAC'
-    else:
-        camera = 'NAC'
+    id = vicar_dict['INSTRUMENT_ID']
+    camera = id[3:]+'C'
 
-    filter1, filter2 = vicar_dict['FILTER_NAME']
+    if 'FILTER_NAME' in vicar_dict:
+        filter1, filter2 = vicar_dict['FILTER_NAME']
+    else:
+        filter1 = vicar_dict['FILTER1_NAME']
+        filter2 = vicar_dict['FILTER2_NAME']
 
     gain_mode = None
 

--- a/oops/hosts/cassini/iss.py
+++ b/oops/hosts/cassini/iss.py
@@ -45,7 +45,7 @@ def from_file(filespec, fast_distortion=True,
     # Get key information from the header
     tstop = julian.tdb_from_tai(julian.tai_from_iso(vic['IMAGE_TIME']))
     texp = max(1.e-3, vicar_dict['EXPOSURE_DURATION']) / 1000.
-    tstart = tstop - 0.5*texp
+    tstart = tstop - texp
     mode = vicar_dict['INSTRUMENT_MODE_ID']
 
     id = vicar_dict['INSTRUMENT_ID']


### PR DESCRIPTION
Resolves #171 

CASISS START_TIME replaced with IMAGE_TIME - texp/2
CASISS camera name derived from INSTRUMENT_ID
CASISS filters taken from FILTER1_NAME / FILTER2_NAME if FILTER_NAME field not present in vicar label 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request fixes Cassini ISS image processing by switching from START_TIME to IMAGE_TIME, adjusting time calculations based on exposure duration, updating camera naming logic, and improving filter extraction. These changes aim to resolve processing errors and enhance data reliability for early Cassini images.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>